### PR TITLE
CI: update fetch-system.util image (registry.goboolean.io/fetch-system/util/preparer) to tag 4abf59c in profile dev

### DIFF
--- a/fetch-system.util/kustomize/overlays/dev/preparer-job.yaml
+++ b/fetch-system.util/kustomize/overlays/dev/preparer-job.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
         - name: preparer
-          image: "registry.goboolean.io/fetch-system/util/preparer:e45c045"
+          image: "registry.goboolean.io/fetch-system/util/preparer:4abf59c"
           env:
             - name: POSTGRES_HOST
               value: <POSTGRES_HOST>


### PR DESCRIPTION
This PR updates fetch-system.util image (registry.goboolean.io/fetch-system/util/preparer) to tag 4abf59c in profile dev