### PR TITLE
CI: update fetch-system.util image (registry.goboolean.io/fetch-system/util/db-initer) to tag 8c43c6f in profile dev

### DIFF
--- a/fetch-system.util/kustomize/overlays/dev/db-initer-job.yaml
+++ b/fetch-system.util/kustomize/overlays/dev/db-initer-job.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
         - name: db-initer
-          image: "registry.goboolean.io/fetch-system/util/db-initer:f50c2e6"
+          image: "registry.goboolean.io/fetch-system/util/db-initer:8c43c6f"
           env:
             - name: POSTGRES_HOST
               value: <POSTGRES_HOST>


### PR DESCRIPTION
This PR updates fetch-system.util image (registry.goboolean.io/fetch-system/util/db-initer) to tag 8c43c6f in profile dev