### PR TITLE
CI: update fetch-system.streams image (registry.goboolean.io/fetch-system/streams) to tag db64d2a in profile dev

### DIFF
--- a/fetch-system.streams/kustomize/overlays/dev/deployment.yaml
+++ b/fetch-system.streams/kustomize/overlays/dev/deployment.yaml
@@ -9,7 +9,7 @@ spec:
     spec:
       containers:
         - name: fetch-system-streams
-          image: "registry.goboolean.io/fetch-system/streams:f75d930"
+          image: "registry.goboolean.io/fetch-system/streams:db64d2a"
           resources:
             requests:
               cpu: 2000m


### PR DESCRIPTION
This PR updates fetch-system.streams image (registry.goboolean.io/fetch-system/streams) to tag db64d2a in profile dev