### PR TITLE
CI: update fetch-system.streams image (registry.goboolean.io/fetch-system/streams) to tag 345f45c in profile dev

### DIFF
--- a/fetch-system.streams/kustomize/overlays/dev/deployment.yaml
+++ b/fetch-system.streams/kustomize/overlays/dev/deployment.yaml
@@ -9,7 +9,7 @@ spec:
     spec:
       containers:
         - name: fetch-system-streams
-          image: "registry.goboolean.io/fetch-system/streams:db64d2a"
+          image: "registry.goboolean.io/fetch-system/streams:345f45c"
           resources:
             requests:
               cpu: 2000m


### PR DESCRIPTION
This PR updates fetch-system.streams image (registry.goboolean.io/fetch-system/streams) to tag 345f45c in profile dev