### PR TITLE
CI: update fetch-system.streams image (registry.goboolean.io/fetch-system/streams) to tag 645ff1a in profile dev

### DIFF
--- a/fetch-system.streams/kustomize/overlays/dev/deployment.yaml
+++ b/fetch-system.streams/kustomize/overlays/dev/deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: streams
-          image: "registry.goboolean.io/fetch-system/streams:345f45c"
+          image: "registry.goboolean.io/fetch-system/streams:645ff1a"
           resources:
             requests:
               cpu: 2000m


### PR DESCRIPTION
This PR updates fetch-system.streams image (registry.goboolean.io/fetch-system/streams) to tag 645ff1a in profile dev