### PR TITLE
CI: update fetch-system.util image (registry.goboolean.io/fetch-system/util/preparer) to tag 00484cc in profile dev

### DIFF
--- a/fetch-system.util/kustomize/overlays/dev/preparer-job.yaml
+++ b/fetch-system.util/kustomize/overlays/dev/preparer-job.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
         - name: preparer
-          image: "registry.goboolean.io/fetch-system/util/preparer:cdfa3d3"
+          image: "registry.goboolean.io/fetch-system/util/preparer:00484cc"
           env:
             - name: POSTGRES_HOST
               value: <POSTGRES_HOST>


### PR DESCRIPTION
This PR updates fetch-system.util image (registry.goboolean.io/fetch-system/util/preparer) to tag 00484cc in profile dev